### PR TITLE
Add a check to prevent multiple RenderDoc initialization

### DIFF
--- a/src/main/java/net/neoforged/doctor/RenderDocLaunchAgent.java
+++ b/src/main/java/net/neoforged/doctor/RenderDocLaunchAgent.java
@@ -13,10 +13,18 @@ import java.lang.foreign.*;
 import java.lang.instrument.Instrumentation;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class RenderDocLaunchAgent {
 
+    private static AtomicBoolean hasLoaded = new AtomicBoolean();
+
     public static void load() {
+        //Avoid loading multiple times if we were specified multiple times by accident
+        if (hasLoaded.compareAndExchange(false, true)) {
+            return;
+        }
+
         System.out.printf("Loading RenderDoc...%n");
 
         //Check if we are on mac:


### PR DESCRIPTION
Due to https://youtrack.jetbrains.com/issue/IDEA-235974 the launch agent for launching RenderDoc can sometimes be invoked twice. This check should work around that by exiting early from the load() method if the library has already been loaded and initialized.