### PR TITLE
Change readme to reflect the correct maven artifact

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@
 ### Usage
 Add the published artifact:
 ```
-net.neoforged:RenderNurse:0.0.4
+implementation "net.neoforged:render-nurse:0.0.14"
 ```
 or any other version you want to use to your runtime classpath.
 It has no compile dependency and no API other than the system properties that should be set for startup.

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@
 ### Usage
 Add the published artifact:
 ```
-implementation "net.neoforged:render-nurse:0.0.14"
+net.neoforged:render-nurse:0.0.14
 ```
 or any other version you want to use to your runtime classpath.
 It has no compile dependency and no API other than the system properties that should be set for startup.


### PR DESCRIPTION
The currently listed artifact does not exist, I did find version 0.0.9 there, which has a hardcoded renderdoc library location. This should be the correct artifact